### PR TITLE
Fix scroll reset on patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ $ bower install hirst-dialog
 </hirst-confirm-dialog>
 ```
 
+## Disable Patch
+
+The component involves `patch`, the workaround of bugs that may happen on different targets. The bugs can be fixed with the `patch`, e.g. [Wrong caret position bug on iOS 11](https://bugs.webkit.org/show_bug.cgi?id=176896).
+
+By default, the `patch` is enabled, but it can't be disabled with the following:
+```html
+<body hirst-dialog-patch="disabled">
+    ...
+</hirst-confirm-dialog>
+```
+
 ## Development
 
 ### Prerequisites

--- a/demo/index.html
+++ b/demo/index.html
@@ -81,7 +81,7 @@
   </custom-style>
 </head>
 
-<body>
+<body hirst-dialog-patch>
 <div class="vertical-section-container centered">
 
   <h3>Basic action dialog</h3>

--- a/hirst-dialog-base.html
+++ b/hirst-dialog-base.html
@@ -160,9 +160,19 @@ Custom property | Description | Default
       }
 
       /**
+       * Check if patch is enabled for the component
+       */
+      _patchEnabled() {
+        return document.body.getAttribute('hirst-dialog-patch') !== null;
+      }
+
+      /**
        * Apply patch before dialog opened
        */
       _applyPatch() {
+        if (!this._patchEnabled()) {
+          return;
+        }
         if (this._isIOS11()) {
           this._bodyPosition = document.body.style.position;
           this._bodyWidth = document.body.style.width;
@@ -175,6 +185,9 @@ Custom property | Description | Default
        * Restore patch after dialog closed
        */
       _restorePatch() {
+        if (!this._patchEnabled()) {
+          return;
+        }
         if (this._isIOS11()) {
           document.body.style.position = this._bodyPosition;
           document.body.style.width = this._bodyWidth;

--- a/hirst-dialog-base.html
+++ b/hirst-dialog-base.html
@@ -175,9 +175,12 @@ Custom property | Description | Default
        * Apply patch before dialog opened
        */
       _applyPatch() {
-        if (!this._patchEnabled()) {
+        if (!this._patchEnabled() || this._patchApplied) {
           return;
         }
+
+        this._patchApplied = true;
+
         if (this._isIOS11()) {
           this._bodyPosition = document.body.style.position;
           this._bodyLeft = document.body.style.left;
@@ -200,9 +203,12 @@ Custom property | Description | Default
        * Restore patch after dialog closed
        */
       _restorePatch() {
-        if (!this._patchEnabled()) {
+        if (!this._patchEnabled() || !this._patchApplied) {
           return;
         }
+
+        this._patchApplied = false;
+
         if (this._isIOS11()) {
           document.body.style.position = this._bodyPosition;
           document.body.style.left = this._bodyLeft;
@@ -214,6 +220,9 @@ Custom property | Description | Default
         }
       }
 
+      /**
+       * Patch target - Safari on iOS 11
+       */
       _isIOS11() {
         return /iPad|iPhone|iPod/.test(navigator.userAgent) && /OS 11_/.test(navigator.userAgent);
       }

--- a/hirst-dialog-base.html
+++ b/hirst-dialog-base.html
@@ -175,9 +175,19 @@ Custom property | Description | Default
         }
         if (this._isIOS11()) {
           this._bodyPosition = document.body.style.position;
+          this._bodyLeft = document.body.style.left;
+          this._bodyTop = document.body.style.top;
           this._bodyWidth = document.body.style.width;
+          this._bodyHeight = document.body.style.height;
+          this._bodyOverflow = document.body.style.overflow;
+          this._docScrollX = window.scrollX;
+          this._docScrollY = window.scrollY;
           document.body.style.position = 'fixed';
+          document.body.style.left = -this._docScrollX + 'px';
+          document.body.style.top = -this._docScrollY + 'px';
           document.body.style.width = document.body.style.width ? document.body.style.width : '100%';
+          document.body.style.height = '100%';
+          document.body.style.overflow = 'hidden';
         }
       }
 
@@ -190,7 +200,12 @@ Custom property | Description | Default
         }
         if (this._isIOS11()) {
           document.body.style.position = this._bodyPosition;
+          document.body.style.left = this._bodyLeft;
+          document.body.style.top = this._bodyTop;
           document.body.style.width = this._bodyWidth;
+          document.body.style.height = this._bodyHeight;
+          document.body.style.overflow = this._bodyOverflow;
+          window.scrollTo(this._docScrollX, this._docScrollY);
         }
       }
 

--- a/hirst-dialog-base.html
+++ b/hirst-dialog-base.html
@@ -42,6 +42,11 @@ Custom property | Description | Default
   <template>
     <style>
       paper-dialog {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        margin: 0px;
+        transform: translate(-50%, -50%);
         --paper-dialog: {
           width: 100vw;
           height: 100vh;

--- a/hirst-dialog-base.html
+++ b/hirst-dialog-base.html
@@ -165,17 +165,10 @@ Custom property | Description | Default
       }
 
       /**
-       * Check if patch is enabled for the component
-       */
-      _patchEnabled() {
-        return document.body.getAttribute('hirst-dialog-patch') !== null;
-      }
-
-      /**
        * Apply patch before dialog opened
        */
       _applyPatch() {
-        if (!this._patchEnabled() || this._patchApplied) {
+        if (this._patchDisabled() || this._patchApplied) {
           return;
         }
 
@@ -203,7 +196,7 @@ Custom property | Description | Default
        * Restore patch after dialog closed
        */
       _restorePatch() {
-        if (!this._patchEnabled() || !this._patchApplied) {
+        if (this._patchDisabled() || !this._patchApplied) {
           return;
         }
 
@@ -218,6 +211,13 @@ Custom property | Description | Default
           document.body.style.overflow = this._bodyOverflow;
           window.scrollTo(this._docScrollX, this._docScrollY);
         }
+      }
+
+      /**
+       * Check if dialog patch is disabled
+       */
+      _patchDisabled() {
+        return document.body.getAttribute('hirst-dialog-patch') === 'disabled';
       }
 
       /**


### PR DESCRIPTION
# Fix scroll reset on patch

* Fixed the issue that scroll position is reset after dialog opened/closed
* Fixed the issue that dialog is positioned below out of viewport once screen is scrolled down

Related issue: #7 